### PR TITLE
Create initial version of example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ you are interested in battle-tested, production-ready Terraform code, check out 
 
 ## How do you deploy the infrastructure in this repo?
 
-Pre-requisites: 
+
+### Pre-requisites 
 
 1. Install [Terraform](https://www.terraform.io/) and [Terragrunt](https://github.com/gruntwork-io/terragrunt).
 1. Update the `bucket` parameter in `non-prod/terraform.tfvars` and `prod/terraform.tfvars` to unique names. We use S3
@@ -31,7 +32,8 @@ Pre-requisites:
 1. Configure your AWS credentials using one of the supported [authentication 
    mechanisms](https://www.terraform.io/docs/providers/aws/#authentication).
 
-To deploy a single module:    
+
+### Deploying a single module    
 
 1. `cd` into the module's folder (e.g. `cd non-prod/us-east-1/qa/mysql`). 
 1. Note: if you're deploying the MySQL DB, you'll need to configure your DB password as an environment variable:
@@ -39,12 +41,55 @@ To deploy a single module:
 1. Run `terragrunt plan` to see the changes you're about to apply.
 1. If the plan looks good, run `terragrunt apply`.
 
-To deploy everything in a single region:
+
+### Deploying all modules in a region
 
 1. `cd` into the region folder (e.g. `cd non-prod/us-east-1`).
 1. Configure the password for the MySQL DB as an environment variable: `export TF_VAR_master_password=(...)`.
 1. Run `terragrunt plan-all` to see all the changes you're about to apply.
 1. If the plan looks good, run `terragrunt apply-all`.
+
+
+### Testing the infrastructure after it's deployed
+
+After each module is finished deploying, it will write a bunch of outputs to the screen. For example, the ASG will
+output something like the following:
+
+```
+Outputs:
+
+asg_name = tf-asg-00343cdb2415e9d5f20cda6620
+asg_security_group_id = sg-d27df1a3
+elb_dns_name = webserver-example-prod-1234567890.us-east-1.elb.amazonaws.com
+elb_security_group_id = sg-fe62ee8f
+url = http://webserver-example-prod-1234567890.us-east-1.elb.amazonaws.com:80
+```
+
+A minute or two after the deployment finishes, and the servers in the ASG have passed their health checks, you should
+be able to test the `url` output in your browser or with `curl`:
+
+```
+curl http://webserver-example-prod-1234567890.us-east-1.elb.amazonaws.com:80
+
+Hello, World
+```
+
+Similarly, the MySQL module produces outputs that will look something like this:
+
+```
+Outputs:
+
+arn = arn:aws:rds:us-east-1:1234567890:db:terraform-00d7a11c1e02cf617f80bbe301
+db_name = mysql_prod
+endpoint = terraform-1234567890.abcdefghijklmonp.us-east-1.rds.amazonaws.com:3306
+```
+
+You can use the `endpoint` and `db_name` outputs with any MySQL client:
+ 
+```
+mysql --host=terraform-1234567890.abcdefghijklmonp.us-east-1.rds.amazonaws.com:3306 --user=admin --password mysql_prod
+```
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ you are interested in battle-tested, production-ready Terraform code, check out 
 
 Pre-requisites: 
 
-1. install [Terraform](https://www.terraform.io/) and [Terragrunt](https://github.com/gruntwork-io/terragrunt).
+1. Install [Terraform](https://www.terraform.io/) and [Terragrunt](https://github.com/gruntwork-io/terragrunt).
 1. Update the `bucket` parameter in `non-prod/terraform.tfvars` and `prod/terraform.tfvars` to unique names. We use S3
    [as a Terraform backend](https://www.terraform.io/docs/backends/types/s3.html) to store your Terraform state, and
    S3 bucket names must be globally unique. The names currently in the file are already taken, so you'll have to 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# Example infrastructure-live for Terragrunt
+
+This repo, along with the [terragrunt-infrastructure-modules-example 
+repo](https://github.com/gruntwork-io/terragrunt-infrastructure-modules-example), show an example file/folder structure
+you can use with [Terragrunt](https://github.com/gruntwork-io/terragrunt) to keep your 
+[Terraform](https://www.terraform.io) code DRY. For background information, check out the [Keep your Terraform code
+DRY](https://github.com/gruntwork-io/terragrunt#keep-your-terraform-code-dry) section of the Terragrunt documentation.
+
+This repo shows an example of how to use the modules from the `terragrunt-infrastructure-modules-example` repo to 
+deploy an Auto Scaling Group (ASG) and a MySQL DB across three environments (qa, stage, prod) and two AWS accounts 
+(non-prod, prod), all without duplicating any of the Terraform code. That's because there is just a single copy of 
+the Terraform code, defined in the `terragrunt-infrastructure-modules-example` repo, and in this repo, we solely define
+`terraform.tfvars` files that reference that code (at a specific version, too!) and fill in variables specific to each 
+environment. 
+
+Note: This code is solely for demonstration purposes. This is not production-ready code, so use at your own risk. If 
+you are interested in battle-tested, production-ready Terraform code, check out [Gruntwork](http://www.gruntwork.io/).
+
+
+
+
+## How do you deploy the infrastructure in this repo?
+
+Pre-requisites: 
+
+1. install [Terraform](https://www.terraform.io/) and [Terragrunt](https://github.com/gruntwork-io/terragrunt).
+1. Update the `bucket` parameter in `non-prod/terraform.tfvars` and `prod/terraform.tfvars` to unique names. We use S3
+   [as a Terraform backend](https://www.terraform.io/docs/backends/types/s3.html) to store your Terraform state, and
+   S3 bucket names must be globally unique. The names currently in the file are already taken, so you'll have to 
+   specify your own.
+1. Configure your AWS credentials using one of the supported [authentication 
+   mechanisms](https://www.terraform.io/docs/providers/aws/#authentication).
+
+To deploy a single module:    
+
+1. `cd` into the module's folder (e.g. `cd non-prod/us-east-1/qa/mysql`).    
+1. Run `terragrunt plan` to see the changes you're about to apply.
+1. If the plan looks good, run `terragrunt apply`.
+
+To deploy everything in a single account:
+
+1. `cd` into the account folder (e.g. `cd non-prod`).
+1. Run `terragrunt plan-all` to see all the changes you're about to apply.
+1. If the plan looks good, run `terragrunt apply-all`.
+
+
+
+
+
+## How is the code in this repo organized?
+
+The code in this repo uses the following folder hierarchy:
+ 
+```
+account
+ └ _global
+ └ region
+    └ _global
+    └ environment
+       └ resource
+```
+
+Where:
+
+* **Account**: At the top level are each of your AWS accounts, such as `stage-account`, `prod-account`, `mgmt-account`, 
+  etc. If you have everything deployed in a single AWS account, there will just be a single folder at the root (e.g. 
+  `main-account`).
+  
+* **Region**: Within each account, there will be one or more [AWS 
+  regions](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html), such as 
+  `us-east-1`, `eu-west-1`, and `ap-southeast-2`, where you've deployed resources. There may also be a `_global` 
+  folder that defines resources that are available across all the AWS regions in this account, such as IAM users, 
+  Route 53 hosted zones, and CloudTrail. 
+
+* **Environment**: Within each region, there will be one or more "environments", such as `qa`, `stage`, etc. Typically, 
+  an environment will correspond to a single [AWS Virtual Private Cloud (VPC)](https://aws.amazon.com/vpc/), which 
+  isolates that environment from everything else in that AWS account. There may also be a `_global` folder 
+  that defines resources that are available across all the environments in this AWS region, such as Route 53 A records, 
+  SNS topics, and ECR repos.
+  
+* **Resource**: Within each environment, you deploy all the resources for that environment, such as EC2 Instances, Auto
+  Scaling Groups, ECS Clusters, Databases, Load Balancers, and so on. Note that the Terraform code for most of these
+  resources lives in the [terragrunt-infrastructure-modules-example 
+  repo](https://github.com/gruntwork-io/terragrunt-infrastructure-modules-example).

--- a/README.md
+++ b/README.md
@@ -33,13 +33,16 @@ Pre-requisites:
 
 To deploy a single module:    
 
-1. `cd` into the module's folder (e.g. `cd non-prod/us-east-1/qa/mysql`).    
+1. `cd` into the module's folder (e.g. `cd non-prod/us-east-1/qa/mysql`). 
+1. Note: if you're deploying the MySQL DB, you'll need to configure your DB password as an environment variable:
+   `export TF_VAR_master_password=(...)`.
 1. Run `terragrunt plan` to see the changes you're about to apply.
 1. If the plan looks good, run `terragrunt apply`.
 
-To deploy everything in a single account:
+To deploy everything in a single region:
 
-1. `cd` into the account folder (e.g. `cd non-prod`).
+1. `cd` into the region folder (e.g. `cd non-prod/us-east-1`).
+1. Configure the password for the MySQL DB as an environment variable: `export TF_VAR_master_password=(...)`.
 1. Run `terragrunt plan-all` to see all the changes you're about to apply.
 1. If the plan looks good, run `terragrunt apply-all`.
 

--- a/non-prod/terraform.tfvars
+++ b/non-prod/terraform.tfvars
@@ -1,0 +1,15 @@
+# Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules,
+# remote state, and locking: https://github.com/gruntwork-io/terragrunt
+terragrunt = {
+  # Configure Terragrunt to automatically store tfstate files in an S3 bucket
+  remote_state {
+    backend = "s3"
+    config {
+      encrypt = true
+      bucket = "terragrunt-example-non-prod-terraform-state"
+      key = "${path_relative_to_include()}/terraform.tfstate"
+      region = "us-west-2"
+      lock_table = "terraform-locks"
+    }
+  }
+}

--- a/non-prod/us-east-1/qa/mysql/terraform.tfvars
+++ b/non-prod/us-east-1/qa/mysql/terraform.tfvars
@@ -24,7 +24,7 @@ terragrunt = {
 
 aws_region = "us-east-1"
 
-name           = "mysql-qa"
+name           = "mysql_qa"
 instance_class = "db.t2.micro"
 
 allocated_storage = "20"

--- a/non-prod/us-east-1/qa/mysql/terraform.tfvars
+++ b/non-prod/us-east-1/qa/mysql/terraform.tfvars
@@ -27,7 +27,7 @@ aws_region = "us-east-1"
 name           = "mysql_qa"
 instance_class = "db.t2.micro"
 
-allocated_storage = "20"
+allocated_storage = 20
 storage_type      = "standard"
 
 master_username = "admin"

--- a/non-prod/us-east-1/qa/mysql/terraform.tfvars
+++ b/non-prod/us-east-1/qa/mysql/terraform.tfvars
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+terragrunt = {
+  # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+  # working directory, into a temporary folder, and execute your Terraform commands in that folder.
+  terraform {
+    source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.0.1"
+  }
+
+  # Include all settings from the root terraform.tfvars file
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+
+aws_region = "us-east-1"
+
+name           = "mysql-qa"
+instance_class = "db.t2.micro"
+
+allocated_storage = "20"
+storage_type      = "standard"
+
+master_username = "admin"
+# To avoid storing your DB password in the code, set the password as the environment variable TF_VAR_master_password

--- a/non-prod/us-east-1/qa/mysql/terraform.tfvars
+++ b/non-prod/us-east-1/qa/mysql/terraform.tfvars
@@ -31,4 +31,4 @@ allocated_storage = "20"
 storage_type      = "standard"
 
 master_username = "admin"
-# To avoid storing your DB password in the code, set the password as the environment variable TF_VAR_master_password
+# TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password

--- a/non-prod/us-east-1/qa/webserver-cluster/terraform.tfvars
+++ b/non-prod/us-east-1/qa/webserver-cluster/terraform.tfvars
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+terragrunt = {
+  # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+  # working directory, into a temporary folder, and execute your Terraform commands in that folder.
+  terraform {
+    source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.0.1"
+  }
+
+  # Include all settings from the root terraform.tfvars file
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+
+aws_region = "us-east-1"
+
+name          = "webserver-example-qa"
+instance_type = "t2.micro"
+
+min_size = 2
+max_size = 2
+
+server_port = 8080
+elb_port    = 80

--- a/non-prod/us-east-1/stage/mysql/terraform.tfvars
+++ b/non-prod/us-east-1/stage/mysql/terraform.tfvars
@@ -27,7 +27,7 @@ aws_region = "us-east-1"
 name           = "mysql_stage"
 instance_class = "db.t2.micro"
 
-allocated_storage = "20"
+allocated_storage = 20
 storage_type      = "standard"
 
 master_username = "admin"

--- a/non-prod/us-east-1/stage/mysql/terraform.tfvars
+++ b/non-prod/us-east-1/stage/mysql/terraform.tfvars
@@ -24,7 +24,7 @@ terragrunt = {
 
 aws_region = "us-east-1"
 
-name           = "mysql-stage"
+name           = "mysql_stage"
 instance_class = "db.t2.micro"
 
 allocated_storage = "20"

--- a/non-prod/us-east-1/stage/mysql/terraform.tfvars
+++ b/non-prod/us-east-1/stage/mysql/terraform.tfvars
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+terragrunt = {
+  # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+  # working directory, into a temporary folder, and execute your Terraform commands in that folder.
+  terraform {
+    source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.0.1"
+  }
+
+  # Include all settings from the root terraform.tfvars file
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+
+aws_region = "us-east-1"
+
+name           = "mysql-stage"
+instance_class = "db.t2.micro"
+
+allocated_storage = "20"
+storage_type      = "standard"
+
+master_username = "admin"
+# To avoid storing your DB password in the code, set the password as the environment variable TF_VAR_master_password

--- a/non-prod/us-east-1/stage/mysql/terraform.tfvars
+++ b/non-prod/us-east-1/stage/mysql/terraform.tfvars
@@ -31,4 +31,4 @@ allocated_storage = "20"
 storage_type      = "standard"
 
 master_username = "admin"
-# To avoid storing your DB password in the code, set the password as the environment variable TF_VAR_master_password
+# TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password

--- a/non-prod/us-east-1/stage/webserver-cluster/terraform.tfvars
+++ b/non-prod/us-east-1/stage/webserver-cluster/terraform.tfvars
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+terragrunt = {
+  # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+  # working directory, into a temporary folder, and execute your Terraform commands in that folder.
+  terraform {
+    source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.0.1"
+  }
+
+  # Include all settings from the root terraform.tfvars file
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+
+aws_region = "us-east-1"
+
+name          = "webserver-example-stage"
+instance_type = "t2.micro"
+
+min_size = 2
+max_size = 2
+
+server_port = 8080
+elb_port    = 80

--- a/prod/terraform.tfvars
+++ b/prod/terraform.tfvars
@@ -1,0 +1,15 @@
+# Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules,
+# remote state, and locking: https://github.com/gruntwork-io/terragrunt
+terragrunt = {
+  # Configure Terragrunt to automatically store tfstate files in an S3 bucket
+  remote_state {
+    backend = "s3"
+    config {
+      encrypt = true
+      bucket = "terragrunt-example-prod-terraform-state"
+      key = "${path_relative_to_include()}/terraform.tfstate"
+      region = "us-west-2"
+      lock_table = "terraform-locks"
+    }
+  }
+}

--- a/prod/us-east-1/prod/mysql/terraform.tfvars
+++ b/prod/us-east-1/prod/mysql/terraform.tfvars
@@ -24,7 +24,7 @@ terragrunt = {
 
 aws_region = "us-east-1"
 
-name           = "mysql-prod"
+name           = "mysql_prod"
 instance_class = "db.t2.medium"
 
 allocated_storage = "100"

--- a/prod/us-east-1/prod/mysql/terraform.tfvars
+++ b/prod/us-east-1/prod/mysql/terraform.tfvars
@@ -31,4 +31,4 @@ allocated_storage = "100"
 storage_type      = "standard"
 
 master_username = "admin"
-# To avoid storing your DB password in the code, set the password as the environment variable TF_VAR_master_password
+# TODO: To avoid storing your DB password in the code, set it as the environment variable TF_VAR_master_password

--- a/prod/us-east-1/prod/mysql/terraform.tfvars
+++ b/prod/us-east-1/prod/mysql/terraform.tfvars
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+terragrunt = {
+  # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+  # working directory, into a temporary folder, and execute your Terraform commands in that folder.
+  terraform {
+    source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//mysql?ref=v0.0.1"
+  }
+
+  # Include all settings from the root terraform.tfvars file
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+
+aws_region = "us-east-1"
+
+name           = "mysql-prod"
+instance_class = "db.t2.medium"
+
+allocated_storage = "100"
+storage_type      = "standard"
+
+master_username = "admin"
+# To avoid storing your DB password in the code, set the password as the environment variable TF_VAR_master_password

--- a/prod/us-east-1/prod/mysql/terraform.tfvars
+++ b/prod/us-east-1/prod/mysql/terraform.tfvars
@@ -27,7 +27,7 @@ aws_region = "us-east-1"
 name           = "mysql_prod"
 instance_class = "db.t2.medium"
 
-allocated_storage = "100"
+allocated_storage = 100
 storage_type      = "standard"
 
 master_username = "admin"

--- a/prod/us-east-1/prod/webserver-cluster/terraform.tfvars
+++ b/prod/us-east-1/prod/webserver-cluster/terraform.tfvars
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# This is the configuration for Terragrunt, a thin wrapper for Terraform that supports locking and enforces best
+# practices: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
+terragrunt = {
+  # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
+  # working directory, into a temporary folder, and execute your Terraform commands in that folder.
+  terraform {
+    source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-modules-example.git//asg-elb-service?ref=v0.0.1"
+  }
+
+  # Include all settings from the root terraform.tfvars file
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+
+aws_region = "us-east-1"
+
+name          = "webserver-example-prod"
+instance_type = "t2.medium"
+
+min_size = 3
+max_size = 3
+
+server_port = 8080
+elb_port    = 80


### PR DESCRIPTION
This PR shows how to deploy the example code in https://github.com/gruntwork-io/terragrunt-infrastructure-modules-example/pull/1 across 3 environments in 2 AWS accounts.