### PR TITLE
use list syntax for commands

### DIFF
--- a/non-prod/terraform.tfvars
+++ b/non-prod/terraform.tfvars
@@ -15,7 +15,7 @@ terragrunt = {
   # Configure root level variables that all resources can inherit
   terraform {
     extra_arguments "bucket" {
-      commands = "${get_terraform_commands_that_need_vars()}"
+      commands = ["${get_terraform_commands_that_need_vars()}"]
       optional_var_files = [
           "${get_tfvars_dir()}/${find_in_parent_folders("account.tfvars", "ignore")}"
       ]

--- a/prod/terraform.tfvars
+++ b/prod/terraform.tfvars
@@ -15,7 +15,7 @@ terragrunt = {
   # Configure root level variables that all resources can inherit
   terraform {
     extra_arguments "bucket" {
-      commands = "${get_terraform_commands_that_need_vars()}"
+      commands = ["${get_terraform_commands_that_need_vars()}"]
       optional_var_files = [
           "${get_tfvars_dir()}/${find_in_parent_folders("account.tfvars", "ignore")}"
       ]


### PR DESCRIPTION
When attempting to run `terragrunt plan`, I got the following error:

```At 19:36: expected: IDENT | STRING | ASSIGN | LBRACE got: COMMA```

Traced it back to a lack of square brackets around the value of `commands`.

*Aside:* Thanks for putting this together!