### PR TITLE
Include an example of using yaml to build a hierarchy of variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 # Example infrastructure-live for Terragrunt
 
-This repo, along with the [terragrunt-infrastructure-modules-example 
+This repo, along with the [terragrunt-infrastructure-modules-example
 repo](https://github.com/gruntwork-io/terragrunt-infrastructure-modules-example), show an example file/folder structure
-you can use with [Terragrunt](https://github.com/gruntwork-io/terragrunt) to keep your 
+you can use with [Terragrunt](https://github.com/gruntwork-io/terragrunt) to keep your
 [Terraform](https://www.terraform.io) code DRY. For background information, check out the [Keep your Terraform code
 DRY](https://github.com/gruntwork-io/terragrunt#keep-your-terraform-code-dry) section of the Terragrunt documentation.
 
-This repo shows an example of how to use the modules from the `terragrunt-infrastructure-modules-example` repo to 
-deploy an Auto Scaling Group (ASG) and a MySQL DB across three environments (qa, stage, prod) and two AWS accounts 
-(non-prod, prod), all without duplicating any of the Terraform code. That's because there is just a single copy of 
+This repo shows an example of how to use the modules from the `terragrunt-infrastructure-modules-example` repo to
+deploy an Auto Scaling Group (ASG) and a MySQL DB across three environments (qa, stage, prod) and two AWS accounts
+(non-prod, prod), all without duplicating any of the Terraform code. That's because there is just a single copy of
 the Terraform code, defined in the `terragrunt-infrastructure-modules-example` repo, and in this repo, we solely define
-`terragrunt.hcl` files that reference that code (at a specific version, too!) and fill in variables specific to each 
-environment. 
+`terragrunt.hcl` files that reference that code (at a specific version, too!) and fill in variables specific to each
+environment.
 
-Note: This code is solely for demonstration purposes. This is not production-ready code, so use at your own risk. If 
+Note: This code is solely for demonstration purposes. This is not production-ready code, so use at your own risk. If
 you are interested in battle-tested, production-ready Terraform code, check out [Gruntwork](http://www.gruntwork.io/).
 
 
@@ -24,21 +24,21 @@ you are interested in battle-tested, production-ready Terraform code, check out 
 ## How do you deploy the infrastructure in this repo?
 
 
-### Pre-requisites 
+### Pre-requisites
 
-1. Install [Terraform](https://www.terraform.io/) version `0.12.0` or newer and 
-   [Terragrunt](https://github.com/gruntwork-io/terragrunt) version `v0.19.0` or newer. 
+1. Install [Terraform](https://www.terraform.io/) version `0.12.0` or newer and
+   [Terragrunt](https://github.com/gruntwork-io/terragrunt) version `v0.20.0` or newer.
 1. Update the `bucket` parameter in `non-prod/terragrunt.hcl` and `prod/terragrunt.hcl` to unique names. We use S3
    [as a Terraform backend](https://www.terraform.io/docs/backends/types/s3.html) to store your Terraform state, and
-   S3 bucket names must be globally unique. The names currently in the file are already taken, so you'll have to 
-   specify your own.
-1. Configure your AWS credentials using one of the supported [authentication 
+   S3 bucket names must be globally unique. The names currently in the file are already taken, so you'll have to
+   specify your own. Alternatives, you can set the environment variable `TG_BUCKET_PREFIX` to set a custom prefix.
+1. Configure your AWS credentials using one of the supported [authentication
    mechanisms](https://www.terraform.io/docs/providers/aws/#authentication).
 
 
-### Deploying a single module    
+### Deploying a single module
 
-1. `cd` into the module's folder (e.g. `cd non-prod/us-east-1/qa/mysql`). 
+1. `cd` into the module's folder (e.g. `cd non-prod/us-east-1/qa/mysql`).
 1. Note: if you're deploying the MySQL DB, you'll need to configure your DB password as an environment variable:
    `export TF_VAR_master_password=(...)`.
 1. Run `terragrunt plan` to see the changes you're about to apply.
@@ -88,7 +88,7 @@ endpoint = terraform-1234567890.abcdefghijklmonp.us-east-1.rds.amazonaws.com:330
 ```
 
 You can use the `endpoint` and `db_name` outputs with any MySQL client:
- 
+
 ```
 mysql --host=terraform-1234567890.abcdefghijklmonp.us-east-1.rds.amazonaws.com:3306 --user=admin --password mysql_prod
 ```
@@ -101,7 +101,7 @@ mysql --host=terraform-1234567890.abcdefghijklmonp.us-east-1.rds.amazonaws.com:3
 ## How is the code in this repo organized?
 
 The code in this repo uses the following folder hierarchy:
- 
+
 ```
 account
  └ _global
@@ -113,28 +113,28 @@ account
 
 Where:
 
-* **Account**: At the top level are each of your AWS accounts, such as `stage-account`, `prod-account`, `mgmt-account`, 
-  etc. If you have everything deployed in a single AWS account, there will just be a single folder at the root (e.g. 
+* **Account**: At the top level are each of your AWS accounts, such as `stage-account`, `prod-account`, `mgmt-account`,
+  etc. If you have everything deployed in a single AWS account, there will just be a single folder at the root (e.g.
   `main-account`).
-  
-* **Region**: Within each account, there will be one or more [AWS 
-  regions](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html), such as 
-  `us-east-1`, `eu-west-1`, and `ap-southeast-2`, where you've deployed resources. There may also be a `_global` 
-  folder that defines resources that are available across all the AWS regions in this account, such as IAM users, 
-  Route 53 hosted zones, and CloudTrail. 
 
-* **Environment**: Within each region, there will be one or more "environments", such as `qa`, `stage`, etc. Typically, 
-  an environment will correspond to a single [AWS Virtual Private Cloud (VPC)](https://aws.amazon.com/vpc/), which 
-  isolates that environment from everything else in that AWS account. There may also be a `_global` folder 
-  that defines resources that are available across all the environments in this AWS region, such as Route 53 A records, 
+* **Region**: Within each account, there will be one or more [AWS
+  regions](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html), such as
+  `us-east-1`, `eu-west-1`, and `ap-southeast-2`, where you've deployed resources. There may also be a `_global`
+  folder that defines resources that are available across all the AWS regions in this account, such as IAM users,
+  Route 53 hosted zones, and CloudTrail.
+
+* **Environment**: Within each region, there will be one or more "environments", such as `qa`, `stage`, etc. Typically,
+  an environment will correspond to a single [AWS Virtual Private Cloud (VPC)](https://aws.amazon.com/vpc/), which
+  isolates that environment from everything else in that AWS account. There may also be a `_global` folder
+  that defines resources that are available across all the environments in this AWS region, such as Route 53 A records,
   SNS topics, and ECR repos.
-  
+
 * **Resource**: Within each environment, you deploy all the resources for that environment, such as EC2 Instances, Auto
   Scaling Groups, ECS Clusters, Databases, Load Balancers, and so on. Note that the Terraform code for most of these
   resources lives in the [terragrunt-infrastructure-modules-example repo](https://github.com/gruntwork-io/terragrunt-infrastructure-modules-example).
 
 ## Creating and using root (account) level variables
 
-In the situation where you have multiple AWS accounts or regions, you often have to pass common variables down to each 
-of your modules. Rather than copy/pasting the same variables into each `terragrunt.hcl` file, in every region, and in 
+In the situation where you have multiple AWS accounts or regions, you often have to pass common variables down to each
+of your modules. Rather than copy/pasting the same variables into each `terragrunt.hcl` file, in every region, and in
 every environment, you can inherit them from the `inputs` defined in the root `terragrunt.hcl` file.

--- a/empty.yaml
+++ b/empty.yaml
@@ -1,0 +1,4 @@
+# This is intentionally empty object. This YAML file is used as a catch all to return an empty map when expected yaml
+# vars do not exist. Note that this file can not be completely empty because terragrunt's yamldecode function expects an
+# object, and it doesn't treat empty files as an empty object (you get a syntax error).
+{}

--- a/non-prod/terragrunt.hcl
+++ b/non-prod/terragrunt.hcl
@@ -1,21 +1,46 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules,
+# remote state, and locking: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
 # Configure Terragrunt to automatically store tfstate files in an S3 bucket
 remote_state {
   backend = "s3"
 
   config = {
     encrypt        = true
-    bucket         = "terragrunt-example-terraform-state-non-prod"
+    bucket         = "${get_env("TG_BUCKET_PREFIX", "")}terragrunt-example-terraform-state-non-prod"
     key            = "${path_relative_to_include()}/terraform.tfstate"
     region         = "us-east-1"
     dynamodb_table = "terraform-locks"
   }
 }
 
+# ---------------------------------------------------------------------------------------------------------------------
+# GLOBAL PARAMETERS
+# These variables apply to all configurations in this subfolder. These are automatically merged into the child
+# `terragrunt.hcl` config via the include block.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  default_yaml_path = find_in_parent_folders("empty.yaml")
+}
+
 # Configure root level variables that all resources can inherit. This is especially helpful with multi-account configs
 # where terraform_remote_state data sources are placed directly into the modules.
-inputs = {
-  aws_region                   = "us-east-1"
-  aws_profile                  = "non-prod"
-  tfstate_global_bucket        = "terragrunt-example-terraform-state-non-prod"
-  tfstate_global_bucket_region = "us-east-1"
-}
+inputs = merge(
+  # Configure Terragrunt to use common vars encoded as yaml to help you keep often-repeated variables (e.g., account ID)
+  # DRY. We use yamldecode to merge the maps into the inputs, as opposed to using varfiles due to a restriction in
+  # Terraform >=0.12 that all vars must be defined as variable blocks in modules. Terragrunt inputs are not affected by
+  # this restriction.
+  yamldecode(
+    file("${get_terragrunt_dir()}/${find_in_parent_folders("env.yaml", local.default_yaml_path)}"),
+  ),
+  yamldecode(
+    file("${get_terragrunt_dir()}/${find_in_parent_folders("region.yaml", local.default_yaml_path)}"),
+  ),
+  {
+    aws_profile                  = "non-prod"
+  },
+)

--- a/non-prod/us-east-1/qa/env.yaml
+++ b/non-prod/us-east-1/qa/env.yaml
@@ -1,0 +1,3 @@
+# These variables apply to this entire environment. They are automatically pulled in using yamldecode and merged into
+# the inputs of the root terragrunt.hcl file.
+environment: "qa"

--- a/non-prod/us-east-1/region.yaml
+++ b/non-prod/us-east-1/region.yaml
@@ -1,0 +1,3 @@
+# These variables apply to this entire region. They are automatically pulled in using yamldecode and merged into
+# the inputs of the root terragrunt.hcl file.
+aws_region: "us-east-1"

--- a/non-prod/us-east-1/stage/env.yaml
+++ b/non-prod/us-east-1/stage/env.yaml
@@ -1,0 +1,3 @@
+# These variables apply to this entire environment. They are automatically pulled in using yamldecode and merged into
+# the inputs of the root terragrunt.hcl file.
+environment: "stage"

--- a/prod/terragrunt.hcl
+++ b/prod/terragrunt.hcl
@@ -1,21 +1,46 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# TERRAGRUNT CONFIGURATION
+# Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules,
+# remote state, and locking: https://github.com/gruntwork-io/terragrunt
+# ---------------------------------------------------------------------------------------------------------------------
+
 # Configure Terragrunt to automatically store tfstate files in an S3 bucket
 remote_state {
   backend = "s3"
 
   config = {
     encrypt        = true
-    bucket         = "terragrunt-example-terraform-state-prod"
+    bucket         = "${get_env("TG_BUCKET_PREFIX", "")}terragrunt-example-terraform-state-prod"
     key            = "${path_relative_to_include()}/terraform.tfstate"
     region         = "us-east-1"
     dynamodb_table = "terraform-locks"
   }
 }
 
+# ---------------------------------------------------------------------------------------------------------------------
+# GLOBAL PARAMETERS
+# These variables apply to all configurations in this subfolder. These are automatically merged into the child
+# `terragrunt.hcl` config via the include block.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  default_yaml_path = find_in_parent_folders("empty.yaml")
+}
+
 # Configure root level variables that all resources can inherit. This is especially helpful with multi-account configs
 # where terraform_remote_state data sources are placed directly into the modules.
-inputs = {
-  aws_region                   = "us-east-1"
-  aws_profile                  = "prod"
-  tfstate_global_bucket        = "terragrunt-example-terraform-state-prod"
-  tfstate_global_bucket_region = "us-east-1"
-}
+inputs = merge(
+  # Configure Terragrunt to use common vars encoded as yaml to help you keep often-repeated variables (e.g., account ID)
+  # DRY. We use yamldecode to merge the maps into the inputs, as opposed to using varfiles due to a restriction in
+  # Terraform >=0.12 that all vars must be defined as variable blocks in modules. Terragrunt inputs are not affected by
+  # this restriction.
+  yamldecode(
+    file("${get_terragrunt_dir()}/${find_in_parent_folders("env.yaml", local.default_yaml_path)}"),
+  ),
+  yamldecode(
+    file("${get_terragrunt_dir()}/${find_in_parent_folders("region.yaml", local.default_yaml_path)}"),
+  ),
+  {
+    aws_profile                  = "prod"
+  },
+)

--- a/prod/us-east-1/prod/env.yaml
+++ b/prod/us-east-1/prod/env.yaml
@@ -1,0 +1,3 @@
+# These variables apply to this entire environment. They are automatically pulled in using yamldecode and merged into
+# the inputs of the root terragrunt.hcl file.
+environment: "prod"

--- a/prod/us-east-1/region.yaml
+++ b/prod/us-east-1/region.yaml
@@ -1,0 +1,3 @@
+# These variables apply to this entire region. They are automatically pulled in using yamldecode and merged into
+# the inputs of the root terragrunt.hcl file.
+aws_region: "us-east-1"


### PR DESCRIPTION
This updates the terragrunt example to show how we use `yamldecode` to include variables in the directory structure. This comes up a lot, so having an example we can point to would be helpful to demonstrate the current recommended practice.