### PR TITLE
Update readme to reflect file rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ you are interested in battle-tested, production-ready Terraform code, check out 
 
 1. Install [Terraform](https://www.terraform.io/) version `0.12.0` or newer and
    [Terragrunt](https://github.com/gruntwork-io/terragrunt) version `v0.23.0` or newer.
-1. Update the `bucket` parameter in `terragrunt.hcl`. We use S3 [as a Terraform
+1. Update the `bucket` parameter in the root `terragrunt.hcl`. We use S3 [as a Terraform
    backend](https://www.terraform.io/docs/backends/types/s3.html) to store your
    Terraform state, and S3 bucket names must be globally unique. The name currently in
    the file is already taken, so you'll have to specify your own. Alternatives, you can

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ you are interested in battle-tested, production-ready Terraform code, check out 
 
 1. Install [Terraform](https://www.terraform.io/) version `0.12.0` or newer and
    [Terragrunt](https://github.com/gruntwork-io/terragrunt) version `v0.23.0` or newer.
-1. Update the `bucket` parameter in `non-prod/terragrunt.hcl` and `prod/terragrunt.hcl` to unique names. We use S3
-   [as a Terraform backend](https://www.terraform.io/docs/backends/types/s3.html) to store your Terraform state, and
-   S3 bucket names must be globally unique. The names currently in the file are already taken, so you'll have to
-   specify your own. Alternatives, you can set the environment variable `TG_BUCKET_PREFIX` to set a custom prefix.
+1. Update the `bucket` parameter in `terragrunt.hcl`. We use S3 [as a Terraform
+   backend](https://www.terraform.io/docs/backends/types/s3.html) to store your
+   Terraform state, and S3 bucket names must be globally unique. The name currently in
+   the file is already taken, so you'll have to specify your own. Alternatives, you can
+   set the environment variable `TG_BUCKET_PREFIX` to set a custom prefix.
 1. Configure your AWS credentials using one of the supported [authentication
    mechanisms](https://www.terraform.io/docs/providers/aws/#authentication).
 


### PR DESCRIPTION
As of 652af17, we no longer need prod/terragrunt.hcl and non-prod/terragrunt.hcl and still we have isolation which is great!  This updates readme for pull request #37.