### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brikis98 @yorinasub17
+@yorinasub17 @zackproser @rhoboat

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@yorinasub17 @zackproser @rhoboat
+* @yorinasub17 @zackproser @rhoboat @denis256


### PR DESCRIPTION
Adds the IaC US team engineers to CODEOWNERS and removes others. Addresses https://github.com/gruntwork-io/cloud-chasers/issues/27. We should add back the maintenance tier owners as well.